### PR TITLE
TGR-138: Adding archive banner note

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "jekyll"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,82 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.1.8)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.4)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.0)
+    ffi (1.17.0-x86_64-darwin)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.28.3)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.3-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.6)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.4)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.1)
+    rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.3.9)
+    rouge (4.5.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.80.6)
+      google-protobuf (~> 4.28)
+      rake (>= 13)
+    sass-embedded (1.80.6-x86_64-darwin)
+      google-protobuf (~> 4.28)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.0)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-23
+
+DEPENDENCIES
+  jekyll
+
+BUNDLED WITH
+   2.5.19

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
-# NYC Space/Time Directory
+# Deprecated
+
+As of October 2024, the Spacetime Directory will no longer be updated by NYPL and will soon be archived. Repositories and data will continue to be available at the project's Github page: https://github.com/nypl-spacetime.
+
+## NYC Space/Time Directory
 
 Website of NYPL's [NYC Space/Time Directory](http://spacetime.nypl.org) project.
 
-# License
+### Running the site
+
+NYPL is no longer maintaining this repo and previous instructions on running the site was unclear. The following is the minimum steps required to run the site locally.
+
+1. You need to run ruby version 3.3.x+
+2. Run `bundle install`
+3. Run `bundle exec jekyll server`
+
+Then go to `localhost:4000` in a browser to see the site.
+
+## License
 
 The original code in this project is licensed under the Creative Commons CC0 1.0 Universal license (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at:
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,9 +12,28 @@
     <script src="{{ site.baseurl }}js/d3.v4.min.js"></script>
     <script src="{{ site.baseurl }}js/moment.min.js"></script>
     <script type="text/javascript" src="{{ site.baseurl }}js/doT.min.js"></script>
+    <style>
+      body {
+        padding-top: 80px;
+      }
+      .archive-banner {
+        padding: 5px;
+        background-color: #F9E08E;
+        color: #000;
+        font-size: 1.3em;
+        position: fixed;
+        text-align: center;
+        top: 0px;
+        width: 100%;
+        z-index: 1000;
+      }
+    </style>
   </head>
   <body>
     <div id="skip" tabindex="-1"><a href="#mainContent">Skip to Main Content</a></div>
+    <div class="archive-banner">
+      As of October 2024, the Spacetime Directory will no longer be updated by NYPL and will soon be archived. Repositories and data will continue to be available at the project's Github page: <a href="https://github.com/nypl-spacetime">https://github.com/nypl-spacetime</a>.
+    </div>
     {% include header.html %}
     <a name="mainContent"></a>
     {{ content }}


### PR DESCRIPTION
Resolves [TGR-138](https://newyorkpubliclibrary.atlassian.net/browse/TGR-138).

Adds banner with archive note.
Adds instructions on how to run the site locally with ruby. This should not change how it's deployed or run on Github Pages.